### PR TITLE
Chore(dev): Configure Deno workspace for Supabase Edge Functions

### DIFF
--- a/supabase/functions/create-checkout-session/deno.json
+++ b/supabase/functions/create-checkout-session/deno.json
@@ -1,3 +1,5 @@
 {
-  "imports": {}
+  "imports": {
+    "std/": "https://deno.land/std@0.224.0/"
+  }
 }


### PR DESCRIPTION
## What changed
- Added `deno.json` to the Supabase Edge Functions workspace
- Ensures proper module resolution for Deno / esm imports
- Improves local DX by eliminating false TypeScript/Deno errors in VS Code

## Why
Supabase Edge Functions run in a Deno environment, which differs from the main Vite + TypeScript app.
Without a local Deno workspace config, editors report incorrect type and module errors.

This change keeps Deno-specific configuration isolated to the edge functions folder without impacting the main app.

## Scope
- No runtime behavior changes
- No frontend changes
- Dev / tooling only
